### PR TITLE
Fix python_version format

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -12,10 +12,7 @@
     "product_vendor": "Elastic",
     "product_version_regex": ".*",
     "min_phantom_version": "5.4.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "logo": "logo_elastic.svg",
     "logo_dark": "logo_elastic_dark.svg",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)