### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Elasticsearch
 
-Publisher: Splunk \
-Connector Version: 3.0.5 \
-Product Vendor: Elastic \
-Product Name: Elasticsearch \
+Publisher: Splunk <br>
+Connector Version: 3.0.5 <br>
+Product Vendor: Elastic <br>
+Product Name: Elasticsearch <br>
 Minimum Product Version: 5.4.0
 
 This app integrates with an Elasticsearch installation to implement ingestion and investigative actions
@@ -43,16 +43,16 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity. This action logs into the device to check the connection and credentials \
-[get config](#action-get-config) - Returns the list of indices and their information currently configured on the ElasticSearch instance \
-[run query](#action-run-query) - Run a search query on the Elasticsearch installation. Please escape any quotes that are part of the query string \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity. This action logs into the device to check the connection and credentials <br>
+[get config](#action-get-config) - Returns the list of indices and their information currently configured on the ElasticSearch instance <br>
+[run query](#action-run-query) - Run a search query on the Elasticsearch installation. Please escape any quotes that are part of the query string <br>
 [on poll](#action-on-poll) - Run a query in elasticsearch and ingest the results
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity. This action logs into the device to check the connection and credentials
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -67,7 +67,7 @@ No Output
 
 Returns the list of indices and their information currently configured on the ElasticSearch instance
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -93,7 +93,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Run a search query on the Elasticsearch installation. Please escape any quotes that are part of the query string
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 The action executes the query on an Elasticsearch installation by doing a POST on the REST endpoint '<b>base_url</b>/<b>index</b>/\_search' with the input <b>query</b> as the data, if specified. Please see the Elasticseach website for query format and documentation.<br>The <b>routing</b> parameter is appended as a parameter in the REST call if specified.<br>As an e.g. the following query returns only the <i>id</i> and <i>name</i> of all the items from the given <b>index</b><br>{ "query": { "match_all": {} }, "\_source": ["id", "name"]}.
@@ -137,7 +137,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Run a query in elasticsearch and ingest the results
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 This will run a query in elasticsearch using the <b>index</b>, <b>routing</b>, and <b>query</b> configured in the app settings and ingest the results. The <b>query</b> is not modified by Splunk SOAR in any way before being requested in elasticsearch. This means that the <b>query</b> must account for relative time between ingestion runs, query limits, and page sizes.<br><br>The <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html">raw JSON response</a> from elasticsearch is passed to a parser script which returns a list of containers and artifacts. If a custom parsing script is not provided, the <a href="/app_resource/elasticsearch_fde8b9da-d38c-45c2-832a-1e1c543ed287/elasticsearch_parser.py">default parsing script</a> is used:<br><pre class="shell"><code>def ingest_parser(data):

--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -12,7 +12,7 @@
     "product_vendor": "Elastic",
     "product_version_regex": ".*",
     "min_phantom_version": "5.4.0",
-    "python_version": "3.9",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "logo": "logo_elastic.svg",
     "logo_dark": "logo_elastic_dark.svg",

--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -398,5 +398,11 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/elasticsearch_connector.py
+++ b/elasticsearch_connector.py
@@ -408,7 +408,7 @@ class ElasticsearchConnector(BaseConnector):
                     try:
                         sys.stdout = debug_out
                         exec(parser, ingest_parser.__dict__)
-                        ret_dict_list = ingest_parser.ingest_parser(data)
+                        ret_dict_list = ingest_parser.ingest_parser(data)  # pylint: disable=no-member
                     except Exception as e:
                         error_message = self._get_error_message_from_exception(e)
                         return action_result.set_status(phantom.APP_ERROR, f"Unable to execute ingest parser: {error_message}")

--- a/elasticsearch_connector.py
+++ b/elasticsearch_connector.py
@@ -14,9 +14,9 @@
 # and limitations under the License.
 """Code that implements calls made to the elasticsearch systems device"""
 
-import imp
 import json
 import sys
+import types
 import urllib.parse as urllib
 
 import phantom.app as phantom
@@ -404,7 +404,7 @@ class ElasticsearchConnector(BaseConnector):
                 if parser:
                     parser_name = config["ingest_parser__filename"]
                     self.save_progress(f"Using specified parser: {parser_name}")
-                    ingest_parser = imp.new_module("custom_parser")
+                    ingest_parser = types.ModuleType("custom_parser")
                     try:
                         sys.stdout = debug_out
                         exec(parser, ingest_parser.__dict__)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)